### PR TITLE
Add Core Version Requirement To Make Module D9 Compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # stripe_color_field
 
 Drupal 8 module. Special Dropdown to indicate color of a stripe.
+This module is also Drupal 9 Compatible !
 
 # Usage
 

--- a/stripe_color_field.info.yml
+++ b/stripe_color_field.info.yml
@@ -2,5 +2,6 @@ name: 'Stripe Color Field'
 type: module
 description: 'Special Dropdown to indicate color of a stripe.'
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: WONDROUS
 configure: stripe_color_field.settings


### PR DESCRIPTION
Jira : https://wearewondrous.atlassian.net/browse/TSM-299
psh : https://pr-24-pynalzq-o5c5cfo2qdnvg.us-2.platformsh.site/  (Hudson Testing Environment)

We can't check this PR directly , so we decided to use Hudson as a testing platform.

### **DESCRIPTION**
This custom module is marked as Drupal 9 incompatible. After inspecting we found that there is no deprecated or removed code so far. And the primary requirement to make any module D9 compatible is to add core version requirement on `.info.yml` file.

We created the tag version [1.0.9](https://github.com/wearewondrous/stripe_color_field/releases/tag/1.0.9) and made necessary changes on `composer.json`  file to use the latest version. 

**Though there is no major code base related changes, we created the tag before approval !**

Functionality Test : https://www.pr-24-pynalzq-o5c5cfo2qdnvg.us-2.platformsh.site/node/add/page

### **GOAL**

- Status report marks this module as compatible 

### **ACCEPTANCE**

- Functionality works fine on all projects